### PR TITLE
v1.0.5 hotfix.1 public notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Changelog
 
-Notable changes per release. Dates are the operator's local time.
+Notable user-facing changes per release. Dates use my local time.
 
 ## [1.0.5 Hotfix 1] — 2026-05-18
 
 ### Changed
 
-- **Cleaner configure flow.** The configure page now uses the native one-page flow with the polished Yukistreams visual pass, anime option toggle, source chips, result sliders, quality/language filters, and a floating ready-to-install bar.
-- **Public-safe install controls.** Copy URL and Install in Stremio still use the encrypted profile install URL, while public users do not see debug manifest controls.
-- **Real-Debrid playback compatibility.** Real-Debrid retrieval avoids filename patterns currently being rejected upstream. This filter is server-side and specific to the Real-Debrid retrieval lane, so TorBox, direct HTTP, and P2P rows are not hidden by it.
+- **Cleaner configure flow.** The setup page now has a calmer one-page layout, clearer source chips, result sliders, quality/language filters, and a floating ready-to-install bar.
+- **Simpler install controls.** Copy URL and Install in Stremio still use the encrypted profile install URL, while public users only see the normal install actions.
+- **Real-Debrid playback compatibility.** Real-Debrid results avoid a few filename patterns that have recently caused upstream playback failures. This only affects the Real-Debrid path; TorBox, direct HTTP, and P2P rows are separate.
 
 ### Fixed
 
-- **Configure control sync.** Presets, anime visibility, result format preview, quality filters, language filters, and result count sliders now update from the actual native form controls.
-- **Configure layout polish.** Debrid key entry, Get key/Add alignment, step glow states, section numerals, footer links, and mobile/tap affordances now match the updated design more closely.
+- **Configure controls.** Presets, anime visibility, result format preview, quality filters, language filters, and result sliders now update more reliably.
+- **Configure polish.** Debrid key entry, Get key/Add alignment, step glow states, section numerals, footer links, and mobile/tap feedback were cleaned up.
 
 ### Note
 
-- Existing installs can keep working. Reconfigure if you want to review the new setup flow, add TorBox, or refresh older source selections.
+- Existing installs can keep working. Reconfigure only if you want to review the new setup flow, add TorBox, or refresh older source selections.
 
 ## [1.0.5] — 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Changelog
+
+Notable changes per release. Dates are the operator's local time.
+
+## [1.0.5 Hotfix 1] — 2026-05-18
+
+### Changed
+
+- **Cleaner configure flow.** The configure page now uses the native one-page flow with the polished Yukistreams visual pass, anime option toggle, source chips, result sliders, quality/language filters, and a floating ready-to-install bar.
+- **Public-safe install controls.** Copy URL and Install in Stremio still use the encrypted profile install URL, while public users do not see debug manifest controls.
+- **Real-Debrid playback compatibility.** Real-Debrid retrieval avoids filename patterns currently being rejected upstream. This filter is server-side and specific to the Real-Debrid retrieval lane, so TorBox, direct HTTP, and P2P rows are not hidden by it.
+
+### Fixed
+
+- **Configure control sync.** Presets, anime visibility, result format preview, quality filters, language filters, and result count sliders now update from the actual native form controls.
+- **Configure layout polish.** Debrid key entry, Get key/Add alignment, step glow states, section numerals, footer links, and mobile/tap affordances now match the updated design more closely.
+
+### Note
+
+- Existing installs can keep working. Reconfigure if you want to review the new setup flow, add TorBox, or refresh older source selections.
+
+## [1.0.5] — 2026-05-17
+
+### Added
+
+- **TorBox support.** You can now configure TorBox alongside Real-Debrid, with provider labels shown in stream rows.
+- **Anime catalog filters.** Anime season, airing, trending, and top rows now expose genre, year, season, airing-day, and seasonal-length filters where Stremio supports catalog extras.
+- **Zero-key Anime preset.** The configure page now has a clearer Anime-focused no-debrid setup for catalogs and supported direct Anime rows.
+- **Catalog warmup.** Default Anime and Asian catalog rows are kept warmer after deploys so first opens are less likely to feel cold.
+
+### Fixed
+
+- **Anime catalog compatibility.** Anime catalog cards now use Kitsu-compatible IDs and preview art/year fields while keeping AniList ranking and metadata internally.
+- **Anime metadata compatibility.** Native Anime detail pages no longer need TMDB enrichment to show normal episode lists.
+- **Content filtering consistency.** Adult filtering now checks both metadata and stream-title signals more consistently.
+- **Catalog cleanup.** Temporarily unreachable source-specific catalog rows are hidden from fresh public configurations.
+- **OneTouchTV subtitles.** OneTouchTV rows can now expose subtitle files when the source provides them.
+
+### Changed
+
+- **Cleaner stream picker default.** Cached debrid and direct HTTP rows appear first. Uncached download rows stay hidden unless you opt into always showing them, or there are no cached/direct rows available.
+- **Issue forms.** Public issue templates now ask for configured debrid provider(s) and apply public-safe triage labels.
+
+### Note
+
+- Reconfigure once after this update if you want to add TorBox, use the zero-key Anime preset, or refresh older Anime catalog installs.
+
+## [1.0.4] — 2026-05-15
+
+### Fixed
+
+- **Anime catalog refresh.** Bumped the addon version after the catalog cleanup so Stremio has a clearer signal to refresh older anime catalog definitions.
+- **Empty catalog caching.** Empty rows are marked as no-store while successful catalog rows keep the short server-backed cache hint.
+
+### Note
+
+- If Anime still shows `EmptyContent` from an older install, reinstall once after this version so Stremio refreshes the manifest.
+
+## [1.0.3 Hotfix] — 2026-05-15
+
+### Fixed
+
+- **Anime catalog visibility.** YS Anime catalogs now render again in Stremio instead of showing `EmptyContent`.
+- **Asian-drama title routing.** Source-native Asian drama rows now open their title pages more reliably.
+- **Cold catalog retries.** Drama catalog previews back off more gracefully when a source is temporarily busy, reducing repeat loading failures.
+- **Recommended catalog cleanup.** The default/recommended setup no longer exposes raw source-specific rows unless you opt into them.
+
+### Note
+
+- If you installed during the short v1.0.2 window and anime or drama catalogs still look empty, reinstall/refresh the addon once so Stremio picks up the corrected manifest.
+
+## [1.0.2] — 2026-05-14
+
+### Added
+
+- **In-app configure cog.** Click the Configure button on Yukistreams in Stremio to open your existing settings — adjustments apply to the same install URL with no reinstall needed.
+- **Anime catalog enrichment.** Side-panel previews now show release year, runtime, rating, and genres from AniList.
+- **First anime direct-HTTP source.** Anikoto-resolved episodes play directly when MediaFlow isn't configured.
+
+### Changed
+
+- **Compact stream picker labels.** Rows now use a short two-line format with source codes (MKV / KKH / OTT / AFX / ANI / KKP / OPH), transport lane (RD / HLS), host glyph, and quality. Easier to scan.
+- **Background metadata refresh.** Catalog and meta data now refresh in the background after the first hit; subsequent home-screen opens are instant. Upstream rate limits are also reduced.
+
+### Fixed
+
+- **Metadata enrichment was inconsistent across catalogs.** Some catalogs were showing weaker preview metadata depending on which user happened to populate the shared cache first. Each user segment now sees consistent metadata.
+- **Catalogs empty after profile rename.** Stremio caches the manifest when you install; renaming your profile no longer makes those cached catalog requests come back empty.
+- **Real-Debrid playback failures.** Blocked / unavailable / rate-limited responses now show a labeled notice clip in Stremio instead of a silent loading state. Affected stream rows are pre-labeled in the picker too.
+- **Korean / Japanese movie catalogs.** Now retry live sources instead of serving stale empty entries.
+- **Short-title torrent matches.** Single-word titles like "Reverse" no longer pull in unrelated torrents.
+- **MKVDrama H1-level quality detection.** Resolution labels fall back to the show page header when individual host links don't carry the resolution.
+
+## [1.0.1] — 2026-05-14
+
+- **Public brand: Yukistreams.** The addon is listed publicly as "Yukistreams" on stremio-addons.net and in the install manifest. Catalog rows use the `YS` prefix for compact home-screen titles: `YS Korean Drama`, `YS MKV Korean Drama`, `YS Asian Movies`, etc.
+- **Configure-page QoL pass.** Show/Hide toggle on Real-Debrid Key + MediaFlow Password. Public-mode trust banner explaining AES-256-GCM encryption. Copy-button "Copied!" confirmation. Submit-button "Generating…" state to prevent duplicate submits. Form-state persistence in localStorage (excluding secrets) so refreshes don't lose your selections. Preset profile buttons (Anime only / Movies & Series / Asian Drama / Everything). Provider grid grouped by category. Inline validation for MediaFlow URL. Edit-existing-profile flow via `/configure?alias=...`.
+- **First anime direct-HTTP source pass.** Added Anikoto route probing (`anikototv.to` primary, `anikoto.cz` fallback) for direct HLS/MP4 links and MediaFlow extractor candidates on observed vidwish/streamzone/cinewave/Kwik hosts.
+- **Regional movie catalog fix.** Korean and Japanese movie rows now retry live source data instead of serving stale empty catalog cache entries.
+- **Cleaner metadata previews.** Provider fallback descriptions now use user-facing wording and can enrich side-panel details from provider metadata even without a TMDB key.
+- **Clearer playback failures.** Real-Debrid playback failures now show a short notice clip instead of leaving Stremio loading without context.
+- **MKVDrama quality labels.** Stream rows keep resolution labels when the container page exposes quality at page level instead of beside each host link.
+- **Public issues repo.** Source remains private; this repo is now the public-facing issue tracker and reference.
+
+## [0.3.0] — 2026-05-12
+
+**Submission-ready public launch hardening and smart playback fallback.**
+
+### Security / privacy
+
+- User install profiles now use short alias links; encrypted credentials are not echoed back after submission.
+- Public installs no longer inherit operator credentials. Each user brings their own Real-Debrid and optional MediaFlow settings.
+- The submitted addon URL opens the configure flow instead of carrying preconfigured private parameters.
+- Public health and status surfaces were reduced to minimal user-safe information.
+- Additional privacy hardening was added around token handling and error output.
+
+### Features
+
+- **Smart MKVDrama click-time failover.** If one host fails at playback time, Yukistreams can fall back to a cached alternate for the same episode without making the user reopen the title.
+
+### Operations
+
+- Public submission docs and issue-tracker copy were prepared for stremio-addons.net.
+
+## [0.2.0] — earlier 2026-05-12
+
+**MKVDrama resolver stable + YS AIO source mapping.**
+
+### Fixed
+
+- **MKVDrama container resolver works end-to-end again.** Restored the `download-<slug>` URL fallback that had been simplified out; relaxed the quality-preference filter at the container-discovery stage so `_c/<token>` stage links with unknown quality are no longer dropped.
+
+### Added
+
+- **YS AIO source mapping phase.** Canonical IDs fan out to mapped provider sources (MKVDrama, KissKH, OneTouchTV) without losing provider-native IDs. MKV-only AIO rows stay provider-native.
+- **Quality-aware container caching.** Lanes like 540p / 720p / 1080p stored as separate cache entries; highest trusted quality promoted as the show default.
+- **Dead `cinemetaEnhance.ts`** (210 lines, unused) removed.
+
+## Pre-0.2.0
+
+Initial closed-source development. Major milestones, in order:
+
+- Initial private Yukistreams gateway
+- Local Real-Debrid resolver cache
+- Anime episode torrent filtering and romanization variants
+- Stremio addon-management and Real-Debrid cache polish
+- YS direct-stream ports for Asian drama sources
+- Asian source recovery checkpoint
+- Localized Asian stream pipeline

--- a/README.md
+++ b/README.md
@@ -1,50 +1,113 @@
 # Yukistreams
 
-## Service status
+A multi-debrid Stremio addon for movies, series, and anime, with a strong drama and Asian-content lane.
 
-[![status](https://img.shields.io/uptimerobot/status/m803060356-07ed0027d059d6ea957bb845?label=service&style=flat-square)](https://stats.uptimerobot.com/pn8O2Kuq2m)
-[![online](https://img.shields.io/endpoint?url=https%3A%2F%2Fstremio.yukistreams.xyz%2Fonline.json&style=flat-square&cacheSeconds=300)](https://stremio.yukistreams.xyz/configure)
-[![7d](https://img.shields.io/uptimerobot/ratio/7/m803060356-07ed0027d059d6ea957bb845?label=7d&style=flat-square)](https://stats.uptimerobot.com/pn8O2Kuq2m)
-[![30d](https://img.shields.io/uptimerobot/ratio/30/m803060356-07ed0027d059d6ea957bb845?label=30d&style=flat-square)](https://stats.uptimerobot.com/pn8O2Kuq2m)
-[![90d](https://img.shields.io/uptimerobot/ratio/90/m803060356-07ed0027d059d6ea957bb845?label=90d&style=flat-square)](https://stats.uptimerobot.com/pn8O2Kuq2m)
+> **Project status:** closed source. This repository is a public-facing issue tracker and reference. The implementation lives in a private repository maintained by the operator. Bug reports and feature requests are very welcome; please file them under [Issues](../../issues).
 
-Live status page: <https://stats.uptimerobot.com/pn8O2Kuq2m>
+## Latest hotfix
 
-The **Asian streaming gateway** for [Stremio](https://www.stremio.com/) — anime and Korean / Japanese / Chinese drama as primary catalogs, with international movies and series alongside.
+v1.0.5 hotfix.1 keeps the v1.0.5 addon line but refreshes the configure page with the cleaner one-page flow, clearer source/result controls, and a public-safe Real-Debrid playback compatibility update. Existing installs can keep working; reconfigure if you want to review the new setup flow or refresh older source selections.
 
-> Bring your own keys. Credentials are AEAD-encrypted into your install URL and are never logged or shared with the operator.
+## What it does
+
+- **Multi-debrid streaming.** Aggregates public torrent indexes (Nyaa, YTS, EZTV, TPB, and ~15 more) and resolves cached results through your own Real-Debrid or TorBox account. Cached/direct rows appear first by default; uncached download rows are optional and otherwise only appear when nothing cached/direct is available.
+- **Direct HTTP sources for Asian drama plus first anime coverage.** MKVDrama, OneTouchTV, AsiaFlix, KKPhim, OPhim, and first-pass Anikoto anime route probing — selected per-user.
+- **Quality-aware Asian-drama resolver.** Keeps per-show and per-quality results warm where possible, with fallback handling so a single host failure is less likely to break playback.
+- **Anime catalogs and cross-references** via AniList, Kitsu, and MAL-style IDs. Yukistreams keeps Anime catalog cards compatible with Stremio while using AniList data behind the scenes, with genre/year/season/day filters where Stremio exposes them.
+- **TMDB-enriched metadata** for `tt:` / `tmdb:` / `tvdb:` IDs when a TMDB key is configured server-side.
+- **Encrypted profile tokens** (AES-256-GCM). Your debrid keys and MediaFlow password are encrypted into your install URL and never logged, never echoed back to clients, never shared with the operator after submission.
 
 ## Install
 
-1. Open **<https://stremio.yukistreams.xyz/configure>**
-2. Pick your providers, paste your own API keys (Real-Debrid / TMDB / NekoBT — all optional, all user-supplied).
-3. Click **Install** — Stremio opens and the addon is added.
+1. Open Stremio.
+2. Click the addon catalog → Community Addons, or paste this URL into the addon search box:
 
-That's it. No account, no signup.
+   ```
+   https://stremio.yukistreams.xyz/manifest.json
+   ```
 
-## What's included
+3. Click Install. Stremio will open the configure page in an iframe.
+4. Add Real-Debrid and/or TorBox service rows, or leave debrid services empty for zero-key Anime/Asian-source testing. Pick your catalog/quality/language preferences, then click **Install in Stremio** or **Copy URL**.
 
-- **Anime** — Multiple sources (RD + HTTP)
-- **Asian drama** — Multiple sources (MKV, KKH, OTT, etc.)
-- **Movies & series** — International indexes (YTS, EZTV, ThePirateBay, TorrentGalaxy, 1337x, RARBG)
-- **Catalogs** — Anime, Asia Movie, Asian Drama Series.
+The same install URL works on PC, mobile, and Shield TV via Stremio's account sync.
 
-## Support the Project
+### Don't have a debrid account?
 
-Yukistreams is solo-operated and community-driven. 🚀
+The addon still works without a debrid key — you'll see Anime catalogs, supported catalog filters, direct HTTP rows from supported Asian-drama sources, and anime HTTP rows only when a source is direct-safe or your profile has MediaFlow configured. A supported debrid account is recommended for the full experience.
 
-- ⭐ **Star** this repo
-- [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/Y8Y21YZBGA)
-- 🐛 **Report issues** via the [issue tracker](https://github.com/kunolabs/yukistreams-addon/issues/new/choose) — auto-tagged templates make triage fast
+## Direct HTTP Sources
 
-**Heads up:** never paste your install URL anywhere — it's an active credential. Anyone with it can use your embedded API keys via this addon.
+Yukistreams can show some playback rows even when you do not configure Real-Debrid, TorBox, or MediaFlow. These rows return the final upstream media URL to Stremio. The operator's VPS does lightweight lookup only and does not relay video bytes for these direct rows.
 
-## Privacy
+| Source | Lane | Direct without debrid | Needs MediaFlow | Notes |
+| --- | --- | ---: | ---: | --- |
+| MKVDrama | Asian drama | [x] | [ ] | Direct rows are available when the source resolves to hosts such as Pixeldrain, Gofile, or other final media-file URLs. Protected/container hosts may still need a debrid route or source-specific resolver discovery. |
+| KissKH | Asian drama/movie | [x] | [ ] | Emits final HLS/video URLs directly where available. |
+| OneTouchTV | Asian drama/movie | [x] | [~] | Direct HLS-capable. User MediaFlow can help for some HLS handling when configured, but it is not required for direct rows. |
+| AsiaFlix | Asian drama/movie | [x] | [~] | Direct HLS/MP4/SharePoint rows where available. Some embed hosts are MediaFlow fallback candidates. |
+| KKPhim | Vietnamese movie/series | [x] | [~] | Final HLS sources can play directly; MediaFlow wrapping may be used by profiles that configured it. |
+| OPhim | Vietnamese movie/series | [x] | [ ] | Final HLS source rows are direct. |
+| Anikoto | Anime | [x] | [~] | Direct HLS rows are available when the upstream host accepts Stremio proxy headers. Embed-only paths may need extractor support. |
+| Anizone | Anime | [x] | [ ] | Direct HLS from episode pages. |
+| ANIMEGG | Anime | [x] | [ ] | Direct MP4 after source redirect resolution. |
+| Anikuro / AllManga / AllAnime | Anime | [x] | [ ] | Uses source API metadata, then returns the decoded upstream HLS URL directly. |
+| AnimePahe via Anikuro | Anime | [x] | [ ] | Direct AnimePahe/Kwik HLS with required referer headers. |
+| Hianime.ms / VidNest AnimePahe | Anime | [x] | [ ] | Direct HLS from the verified Hianime.ms / VidNest AnimePahe lane. |
 
-- The addon operator has no access to your API keys. They are encrypted client-side into your install URL using a key the operator never sees decrypted in-band.
-- The operator does not log search queries, watch history, or stream URLs.
-- All upstream traffic (Real-Debrid, TMDB, trackers) goes via the Yukistreams server, so those services see Yukistreams's IP, not yours.
+Direct HTTP availability is source and episode dependent. If a source only exposes a browser challenge, an embed page without a supported extractor, or a route that requires server-side media transport, Yukistreams skips it instead of proxying video through the public VPS.
 
-## Status
+## Catalogs
 
-This is a small, single-operator instance. There are no uptime guarantees. If `stremio.yukistreams.xyz` is down, sit tight — it'll come back.
+The default install gives you:
+
+- **Anime:** Search · Current Season · Airing · Trending · Top Rated
+- **Movies:** Search · Trending · Top Rated · YS Korean / Japanese / Asian Movies
+- **Series:** Search · Trending · Top Rated · YS Asian Latest / Korean / Japanese / Chinese / Hong Kong Drama
+
+Source-specific catalogs such as MKVDrama and OneTouchTV rows are available in the configure page when they are healthy enough for public use. The `YS` prefix keeps catalog titles short on Stremio's home screen.
+
+## Security model
+
+- The addon does **not** host or store any video content. It indexes publicly available torrent and HTTP sources, and resolves playback through your own supported debrid account.
+- Your debrid keys are encrypted server-side with AES-256-GCM and a server-only secret. The encrypted token is never returned to clients; only the short alias install URL is.
+- The operator runs the addon in `INSTANCE_MODE=public` so per-user fallback to operator credentials is disabled. Every user must bring their own debrid key.
+- The hosted public instance exposes only the normal Stremio install and playback surfaces to users. Operator tools are private and are not part of the public addon API.
+- The addon's configure page is iframe-friendly so the Stremio install flow works.
+
+## What's reportable
+
+**Bugs (please file these):**
+- Streams returning empty for titles you know have public torrents.
+- MKVDrama / OneTouchTV / Anikoto resolver failures with specific titles.
+- Stremio errors after install (no streams, no metadata, wrong language defaults).
+- Configure-page UI bugs.
+
+**Feature requests:**
+- New Asian-drama / anime sources to evaluate.
+- Catalog presets / language filters.
+- Anything you wish was here.
+
+**Not reportable here:**
+- Real-Debrid or TorBox account issues (contact the service's support team).
+- Stremio app bugs (contact the Stremio team).
+- Source-code requests (project is closed source; you can fork the addon API surface yourself but the implementation is not published).
+
+## Acknowledgements
+
+This addon stands on the shoulders of a lot of public Stremio addon prior art:
+
+- **Torrentio** for the torrent-provider matrix and quality/source naming conventions.
+- **Comet** for the debrid-first cache pipeline.
+- **StremThru** for the debrid store abstraction shape.
+- **Amatsu** for anime catalog and AniList/Kitsu/MAL ID compatibility.
+- **Yastream** for KissKH / OneTouchTV / AsiaFlix adapter conventions.
+- **Sootio** for MKVDrama-style HTTP source handling.
+- **AIOmetadata** for the multi-source ID resolver concept.
+
+Each influenced parts of the addon design and is credited with respect.
+
+## Disclaimers
+
+- This addon is provided as-is, with no warranty. Use at your own risk and in compliance with your local laws.
+- You are responsible for your own use of Real-Debrid, TorBox, MediaFlow, and any third-party streaming services configured through this addon.
+- The operator is not affiliated with Stremio, Real-Debrid, TorBox, MediaFlow, or any source provider.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Yukistreams
 
-A multi-debrid Stremio addon for movies, series, and anime, with a strong drama and Asian-content lane.
+A Stremio addon for anime, Asian drama, movies, and series, with optional debrid support.
 
-> **Project status:** closed source. This repository is a public-facing issue tracker and reference. The implementation lives in a private repository maintained by the operator. Bug reports and feature requests are very welcome; please file them under [Issues](../../issues).
+> **Project status:** Yukistreams is closed source. I use this repo for public notes, release updates, and issue reports. Bugs and feature requests are welcome under [Issues](../../issues).
 
 ## Latest hotfix
 
-v1.0.5 hotfix.1 keeps the v1.0.5 addon line but refreshes the configure page with the cleaner one-page flow, clearer source/result controls, and a public-safe Real-Debrid playback compatibility update. Existing installs can keep working; reconfigure if you want to review the new setup flow or refresh older source selections.
+v1.0.5 hotfix.1 is a small polish pass for the current v1.0.5 addon line. The configure page is cleaner, source/result choices are easier to scan, and Real-Debrid playback avoids a few filename patterns that have recently caused upstream failures.
+
+Existing installs can keep working. Reconfigure only if you want to review the new setup flow, add TorBox, or refresh older source choices.
 
 ## What it does
 
@@ -15,7 +17,7 @@ v1.0.5 hotfix.1 keeps the v1.0.5 addon line but refreshes the configure page wit
 - **Quality-aware Asian-drama resolver.** Keeps per-show and per-quality results warm where possible, with fallback handling so a single host failure is less likely to break playback.
 - **Anime catalogs and cross-references** via AniList, Kitsu, and MAL-style IDs. Yukistreams keeps Anime catalog cards compatible with Stremio while using AniList data behind the scenes, with genre/year/season/day filters where Stremio exposes them.
 - **TMDB-enriched metadata** for `tt:` / `tmdb:` / `tvdb:` IDs when a TMDB key is configured server-side.
-- **Encrypted profile tokens** (AES-256-GCM). Your debrid keys and MediaFlow password are encrypted into your install URL and never logged, never echoed back to clients, never shared with the operator after submission.
+- **Encrypted profile tokens** (AES-256-GCM). Your debrid keys and MediaFlow password are encrypted into your install URL and are not shown again after you save.
 
 ## Install
 
@@ -37,7 +39,7 @@ The addon still works without a debrid key — you'll see Anime catalogs, suppor
 
 ## Direct HTTP Sources
 
-Yukistreams can show some playback rows even when you do not configure Real-Debrid, TorBox, or MediaFlow. These rows return the final upstream media URL to Stremio. The operator's VPS does lightweight lookup only and does not relay video bytes for these direct rows.
+Yukistreams can show some playback rows even when you do not configure Real-Debrid, TorBox, or MediaFlow. These rows return the final upstream media URL to Stremio. The server does lightweight lookup only and does not relay video bytes for these direct rows.
 
 | Source | Lane | Direct without debrid | Needs MediaFlow | Notes |
 | --- | --- | ---: | ---: | --- |
@@ -69,9 +71,9 @@ Source-specific catalogs such as MKVDrama and OneTouchTV rows are available in t
 ## Security model
 
 - The addon does **not** host or store any video content. It indexes publicly available torrent and HTTP sources, and resolves playback through your own supported debrid account.
-- Your debrid keys are encrypted server-side with AES-256-GCM and a server-only secret. The encrypted token is never returned to clients; only the short alias install URL is.
-- The operator runs the addon in `INSTANCE_MODE=public` so per-user fallback to operator credentials is disabled. Every user must bring their own debrid key.
-- The hosted public instance exposes only the normal Stremio install and playback surfaces to users. Operator tools are private and are not part of the public addon API.
+- Your debrid keys are encrypted with AES-256-GCM and are not shown back to the browser after setup.
+- The public instance does not use my personal debrid credentials for user installs. Bring your own supported debrid account if you want debrid-backed results.
+- The hosted public instance exposes only the normal Stremio install and playback surfaces to users. Maintainer tools are private and are not part of the public addon API.
 - The addon's configure page is iframe-friendly so the Stremio install flow works.
 
 ## What's reportable
@@ -110,4 +112,4 @@ Each influenced parts of the addon design and is credited with respect.
 
 - This addon is provided as-is, with no warranty. Use at your own risk and in compliance with your local laws.
 - You are responsible for your own use of Real-Debrid, TorBox, MediaFlow, and any third-party streaming services configured through this addon.
-- The operator is not affiliated with Stremio, Real-Debrid, TorBox, MediaFlow, or any source provider.
+- I am not affiliated with Stremio, Real-Debrid, TorBox, MediaFlow, or any source provider.


### PR DESCRIPTION
## Summary

This is a docs-only draft for the public Yukistreams issue/reference repo.

It refreshes the README and changelog for v1.0.5 hotfix.1 in the same user-facing voice I want people to see after the public instance is updated.

## What changed

- Adds the v1.0.5 hotfix.1 note.
- Keeps the wording focused on user-visible configure polish and Real-Debrid playback compatibility.
- Avoids internal implementation details, private routes, and source-repo language.

## Release timing

Keeping this as a draft until the private hotfix is merged, the public instance is deployed, and the public smoke check passes.